### PR TITLE
Create Finnish translation

### DIFF
--- a/harbour-captains-log.desktop
+++ b/harbour-captains-log.desktop
@@ -16,6 +16,7 @@ Name=Captain's Log
 # should be the limit. If your language uses a different script than Latin,
 # please test it before submitting your translation.
 Name[de]=Captain's Log
+Name[fi]=Lokikirja
 
 [X-HarbourBackup]
 BackupPathList=.local/share/harbour-captains-log/

--- a/qml/pages/AboutPage.qml
+++ b/qml/pages/AboutPage.qml
@@ -89,6 +89,7 @@ AboutPageBase {
                 ContributionGroup { title: qsTr("Swedish"); entries: ["Åke Engelbrektson"]},
                 ContributionGroup { title: qsTr("Chinese"); entries: ["dashinfantry"]},
                 ContributionGroup { title: qsTr("German"); entries: ["Gabriel Berkigt", "Mirian Margiani"]}
+                ContributionGroup { title: qsTr("Finnish"); entries: ["Matti Viljanen"]}
 
                 // ContributionGroup { title: qsTr("English"); entries: ["Gabriel Berkigt", "Mirian Margiani"]}
             ]

--- a/translations/harbour-captains-log-fi_FI.ts
+++ b/translations/harbour-captains-log-fi_FI.ts
@@ -31,6 +31,10 @@
         <source>German</source>
         <translation>Saksa</translation>
     </message>
+    <message>
+        <source>Finnish</source>
+        <translation>Suomi</translation>
+    </message>
 </context>
 <context>
     <name>ChangePinPage</name>

--- a/translations/harbour-captains-log-fi_FI.ts
+++ b/translations/harbour-captains-log-fi_FI.ts
@@ -1,0 +1,567 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi_FI" sourcelanguage="en">
+<context>
+    <name>AboutPage</name>
+    <message>
+        <source>Development</source>
+        <translation>Kehitys</translation>
+    </message>
+    <message>
+        <source>A simple diary application for keeping track of your thoughts.</source>
+        <translation>Yksinkertainen päiväkirjasovellus ajatustesi kirjoittamiseksi muistiin.</translation>
+    </message>
+    <message>
+        <source>Programming</source>
+        <translation>Ohjelmointi</translation>
+    </message>
+    <message>
+        <source>Translations</source>
+        <translation>Kääntäjät</translation>
+    </message>
+    <message>
+        <source>Swedish</source>
+        <translation>Ruotsi</translation>
+    </message>
+    <message>
+        <source>Chinese</source>
+        <translation>Kiina</translation>
+    </message>
+    <message>
+        <source>German</source>
+        <translation>Saksa</translation>
+    </message>
+</context>
+<context>
+    <name>ChangePinPage</name>
+    <message>
+        <source>Saved your protection code.</source>
+        <translation>Suojakoodi tallennettu.</translation>
+    </message>
+    <message>
+        <source>Enter your old security code</source>
+        <translation>Anna vanha suojakoodisi</translation>
+    </message>
+    <message>
+        <source>Enter a new security code</source>
+        <translation>Anna uusi suojakoodi</translation>
+    </message>
+</context>
+<context>
+    <name>DateButton</name>
+    <message>
+        <source>Select</source>
+        <comment>fallback text on button to select a date</comment>
+        <translation>Valitse</translation>
+    </message>
+</context>
+<context>
+    <name>EntryElement</name>
+    <message>
+        <source>Edit</source>
+        <translation>Muokkaa</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>Poista</translation>
+    </message>
+    <message>
+        <source>mood: %1</source>
+        <translation>mieliala: %1</translation>
+    </message>
+    <message>
+        <source>Edit: %1</source>
+        <translation>Muokkaa: %1</translation>
+    </message>
+</context>
+<context>
+    <name>ExportPage</name>
+    <message>
+        <source>Export your data</source>
+        <translation>Vie tietosi</translation>
+    </message>
+    <message>
+        <source>Define the file name...</source>
+        <translation>Anna tiedostonimi...</translation>
+    </message>
+    <message>
+        <source>Filename</source>
+        <translation>Tiedostonimi</translation>
+    </message>
+    <message>
+        <source>Export file type selection</source>
+        <translation>Tallenna tiedot muodossa</translation>
+    </message>
+    <message>
+        <source>Select file type:</source>
+        <translation>Valitse tiedostotyyppe:</translation>
+    </message>
+    <message>
+        <source>Plain text</source>
+        <translation>Pelkkä teksti</translation>
+    </message>
+    <message>
+        <source>Comma-separated values (CSV)</source>
+        <translation>Pilkuin erotetut arvot (CSV)</translation>
+    </message>
+    <message>
+        <source>Plain Markdown</source>
+        <translation>Markdown-teksti</translation>
+    </message>
+    <message>
+        <source>Markdown for Pandoc</source>
+        <translation>Pandoc Markdown</translation>
+    </message>
+    <message>
+        <source>never</source>
+        <translation>ei koskaan</translation>
+    </message>
+    <message>
+        <source>Created: {}</source>
+        <translation>Luotu: {}</translation>
+    </message>
+    <message>
+        <source>Changed: {}</source>
+        <translation>Muutettu: {}</translation>
+    </message>
+    <message>
+        <source>changed: {}</source>
+        <translation>muutettu: {}</translation>
+    </message>
+    <message>
+        <source>Title: {}</source>
+        <translation>Otsikko: {}</translation>
+    </message>
+    <message>
+        <source>Entry:
+{}</source>
+        <translation>Kirjoitus: {}</translation>
+    </message>
+    <message>
+        <source>Hashtags: {}</source>
+        <translation>Tagit: {}</translation>
+    </message>
+    <message>
+        <source>Bookmark: {}</source>
+        <translation>Kirjanmerkit: {}</translation>
+    </message>
+    <message>
+        <source>Mood: {}</source>
+        <translation>Mieliala: {}</translation>
+    </message>
+    <message>
+        <source>Diary from {} until {}</source>
+        <translation>Päiväkirja välillä {} - {}</translation>
+    </message>
+    <message>
+        <source>Data exported to: %1</source>
+        <translation>Tiedot viety tiedostoon %1</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation>kyllä</translation>
+    </message>
+    <message>
+        <source>no</source>
+        <translation>ei</translation>
+    </message>
+</context>
+<context>
+    <name>FirstPage</name>
+    <message>
+        <source>About</source>
+        <translation>Tietoja</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation>Haku</translation>
+    </message>
+    <message>
+        <source>Add new entry</source>
+        <translation>Lisää uusi kirjoitus</translation>
+    </message>
+    <message>
+        <source>Settings and Export</source>
+        <translation>Asetukset ja vienti</translation>
+    </message>
+    <message>
+        <source>No entries yet</source>
+        <translation>Ei kirjoituksia</translation>
+    </message>
+    <message>
+        <source>Swipe right to add entries</source>
+        <translation>Lisää kirjoitus pyyhkäisemällä oikealle</translation>
+    </message>
+</context>
+<context>
+    <name>Opal.About</name>
+    <message>
+        <source>About</source>
+        <translation>Tietoja</translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation>Versio %1</translation>
+    </message>
+    <message>
+        <source>Version %1 (%2)</source>
+        <translation>Versio %1 (%2)</translation>
+    </message>
+    <message>
+        <source>Development</source>
+        <translation>Kehitys</translation>
+    </message>
+    <message>
+        <source>show contributors</source>
+        <translation>näytä osallistujat</translation>
+    </message>
+    <message>
+        <source>Homepage</source>
+        <translation>Kotisivu</translation>
+    </message>
+    <message>
+        <source>Translations</source>
+        <translation>Käännökset</translation>
+    </message>
+    <message>
+        <source>Source Code</source>
+        <translation>Lähdekoodi</translation>
+    </message>
+    <message>
+        <source>Donations</source>
+        <translation>Lahjoitukset</translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation>Lisenssi</translation>
+    </message>
+    <message numerus="yes">
+        <source>show license(s)</source>
+        <translation>
+            <numerusform>näytä lisenssi</numerusform>
+            <numerusform>näytä lisenssit</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>show details</source>
+        <translation>näytä tiedot</translation>
+    </message>
+    <message>
+        <source>Contributors</source>
+        <translation>Osallistujat</translation>
+    </message>
+    <message>
+        <source>Acknowledgements</source>
+        <translation>Kiitokset</translation>
+    </message>
+    <message>
+        <source>Thank you!</source>
+        <translation>Kiitos!</translation>
+    </message>
+    <message>
+        <source>Details</source>
+        <translation>Tiedot</translation>
+    </message>
+    <message>
+        <source>External Link</source>
+        <translation>Ulkoinen linkki</translation>
+    </message>
+    <message>
+        <source>Open in browser</source>
+        <translation>Avaa selaimessa</translation>
+    </message>
+    <message>
+        <source>Copied to clipboard: %1</source>
+        <translation>Kopioitu leikepöydälle: %1</translation>
+    </message>
+    <message>
+        <source>Copy to clipboard</source>
+        <translation>Kopioi leiikepöydälle</translation>
+    </message>
+    <message>
+        <source>Please refer to &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
+        <translation>Lisätietoja: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>Download license texts</source>
+        <translation>Lataa lisenssitekstit</translation>
+    </message>
+    <message numerus="yes">
+        <source>License(s)</source>
+        <translation>
+            <numerusform>Lisenssi</numerusform>
+            <numerusform>Lisenssit</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>Note: please check the source code for most accurate information.</source>
+        <translation>Huom: Tarkimman tiedon löydät suoraan lähdekoodista.</translation>
+    </message>
+</context>
+<context>
+    <name>Opal.About.Common</name>
+    <message>
+        <source>If you want to support my work, you can buy me a cup of coffee.</source>
+        <translation>Jos haluat tukea työtäni, voit ostaa minulle kupin kahvia.</translation>
+    </message>
+    <message>
+        <source>You can support this project by contributing, or by donating using any of these services.</source>
+        <translation>Voit tukea tätä projektia joko osallistumalla koodin kehittämiseen, tai tekemällä lahjoituksen johonkin seuraavista palveluista.</translation>
+    </message>
+    <message>
+        <source>Your contributions to translations or code would be most welcome.</source>
+        <translation>Koodipäivityksesi ja käännöksesi ovat mitä tervetulleimpia.</translation>
+    </message>
+</context>
+<context>
+    <name>PinPage</name>
+    <message>
+        <source>Please enter your security code</source>
+        <translation>Anna suojakoodisi</translation>
+    </message>
+    <message>
+        <source>please try again</source>
+        <translation>yritä uudelleen</translation>
+    </message>
+</context>
+<context>
+    <name>ReadPage</name>
+    <message>
+        <source>Edit</source>
+        <translation>Muokkaa</translation>
+    </message>
+    <message>
+        <source>mood:</source>
+        <translation>mieliala:</translation>
+    </message>
+    <message>
+        <source>changed: %1</source>
+        <translation>muokattu: %1</translation>
+    </message>
+</context>
+<context>
+    <name>SearchPage</name>
+    <message>
+        <source>Search</source>
+        <translation>Haku</translation>
+    </message>
+    <message>
+        <source>Filter your results</source>
+        <translation>Suodata tulokset</translation>
+    </message>
+    <message>
+        <source>Search by:</source>
+        <translation>Mistä etsitään:</translation>
+    </message>
+    <message>
+        <source>Creation date</source>
+        <translation>Luontipäivä</translation>
+    </message>
+    <message>
+        <source>Bookmarks</source>
+        <translation>Kirjanmerkit</translation>
+    </message>
+    <message>
+        <source>Hashtag</source>
+        <translation>Tunnisteet</translation>
+    </message>
+    <message>
+        <source>Mood</source>
+        <translation>Mieliala</translation>
+    </message>
+    <message>
+        <source>Filter results by mood</source>
+        <translation>Suodata tulokset mielialan mukaan</translation>
+    </message>
+    <message>
+        <source>Search your entries...</source>
+        <translation>Kirjoita hakuteksti tähän...</translation>
+    </message>
+    <message>
+        <source>Filter:</source>
+        <comment>the mood filter to apply</comment>
+        <translation>Suodatin:</translation>
+    </message>
+    <message>
+        <source>Title and Entry</source>
+        <translation>Otsikko ja kirjoitus</translation>
+    </message>
+    <message>
+        <source>No entries found</source>
+        <translation>Ei kirjoituksia</translation>
+    </message>
+    <message>
+        <source>No entries matched these criteria.</source>
+        <translation>Yksikään kirjoitus ei vastaa hakuehtoja.</translation>
+    </message>
+    <message>
+        <source>from</source>
+        <comment>search entries between &apos;from&apos; and &apos;till&apos;</comment>
+        <translation>Alkaen</translation>
+    </message>
+    <message>
+        <source>till</source>
+        <comment>search entries between &apos;from&apos; and &apos;till&apos;</comment>
+        <translation>Päättyen</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsPage</name>
+    <message>
+        <source>Settings</source>
+        <translation>Asetukset</translation>
+    </message>
+    <message>
+        <source>activate code protection</source>
+        <translation>Käytä suojakoodia</translation>
+    </message>
+    <message>
+        <source>Set Code</source>
+        <translation>Aseta koodi</translation>
+    </message>
+    <message>
+        <source>Change Code</source>
+        <translation>Vaihda koodi</translation>
+    </message>
+    <message>
+        <source>Security</source>
+        <translation>Tietoturva</translation>
+    </message>
+    <message>
+        <source>Export features</source>
+        <translation>Vientitoiminnot</translation>
+    </message>
+    <message>
+        <source>Export data</source>
+        <translation>Vie tiedot</translation>
+    </message>
+</context>
+<context>
+    <name>WritePage</name>
+    <message>
+        <source>Save</source>
+        <translation>Tallenna</translation>
+    </message>
+    <message>
+        <source>New Entry</source>
+        <translation>Uusi kirjoitus</translation>
+    </message>
+    <message>
+        <source>Title</source>
+        <translation>Otsikko</translation>
+    </message>
+    <message>
+        <source>Entry</source>
+        <translation>Kirjoitus</translation>
+    </message>
+    <message>
+        <source>#Hashtags</source>
+        <translation>Tunnisteet</translation>
+    </message>
+    <message>
+        <source>Your mood:</source>
+        <translation>Mielialasi:</translation>
+    </message>
+    <message>
+        <source>Edit Entry</source>
+        <translation>Muokkaa kirjoitusta</translation>
+    </message>
+    <message>
+        <source>How did you feel?</source>
+        <translation>Miltä sinusta tuntui?</translation>
+    </message>
+    <message>
+        <source>How do you feel?</source>
+        <translation>Miltä sinusta tuntuu?</translation>
+    </message>
+    <message>
+        <source>Add a title</source>
+        <translation>Lisää otsikko</translation>
+    </message>
+    <message>
+        <source>What do you want to say?</source>
+        <translation>Mitä haluat kertoa?</translation>
+    </message>
+    <message>
+        <source>Entry...</source>
+        <translation>Kirjoitus...</translation>
+    </message>
+    <message>
+        <source>Hashtags</source>
+        <translation>Tunnisteet</translation>
+    </message>
+    <message>
+        <source>Created:</source>
+        <translation>Luotu:</translation>
+    </message>
+    <message>
+        <source>Last changed:</source>
+        <translation>Viimeksi muokattu:</translation>
+    </message>
+    <message>
+        <source>never</source>
+        <translation>ei koskaan</translation>
+    </message>
+</context>
+<context>
+    <name>harbour-captains-log</name>
+    <message>
+        <source>hh&apos;:&apos;mm</source>
+        <translation>hh&apos;:&apos;mm</translation>
+    </message>
+    <message>
+        <source>d MMM yyyy, hh&apos;:&apos;mm</source>
+        <translation>d MMM yyyy, hh&apos;:&apos;mm</translation>
+    </message>
+    <message>
+        <source>ddd d MMM yyyy, hh&apos;:&apos;mm</source>
+        <translation>ddd d MMM yyyy, hh&apos;:&apos;mm</translation>
+    </message>
+    <message>
+        <source>ddd d MMM yyyy</source>
+        <translation>ddd d MMM yyyy</translation>
+    </message>
+    <message>
+        <source>fantastic</source>
+        <translation>mahtava</translation>
+    </message>
+    <message>
+        <source>good</source>
+        <translation>hyvä</translation>
+    </message>
+    <message>
+        <source>okay</source>
+        <translation>okei</translation>
+    </message>
+    <message>
+        <source>bad</source>
+        <translation>huono</translation>
+    </message>
+    <message>
+        <source>horrible</source>
+        <translation>kamala</translation>
+    </message>
+    <message>
+        <source>&apos;at&apos; hh&apos;:&apos;mm</source>
+        <translation>&apos;kello&apos; hh&apos;:&apos;mm</translation>
+    </message>
+    <message>
+        <source>d MMM yyyy</source>
+        <translation>d MMM yyyy</translation>
+    </message>
+    <message>
+        <source>not okay</source>
+        <translation>ei hyvä</translation>
+    </message>
+    <message>
+        <source>%1 (%2)</source>
+        <comment>1: date, 2: time zone info</comment>
+        <translation>%1 (%2)</translation>
+    </message>
+    <message>
+        <source>Captain&apos;s Log</source>
+        <comment>the app&apos;s name</comment>
+        <translation>Lokikirja</translation>
+    </message>
+</context>
+</TS>

--- a/translations/harbour-captains-log.ts
+++ b/translations/harbour-captains-log.ts
@@ -31,6 +31,10 @@
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Finnish</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChangePinPage</name>


### PR DESCRIPTION
Here's a Finnish translation for you!

I named the app "Lokikirja" and not "Kapteenin lokikirja" because in Finnish, the term "lokikirja" is strongly connected with a ships captain already. It's also short and neat :)

I updated the original translation too (manually) and About page. This was just a quick translation, so I didn't skim through the code to find any other places to add.

Thanks!