### PR TITLE
Remove VACUUM call

### DIFF
--- a/qml/diary.py
+++ b/qml/diary.py
@@ -171,7 +171,6 @@ class Diary:
             self.conn.create_function("REWRITE_NORMALIZED_TAGS", 1,
                                       lambda x: self._normalize_text(x, keep=[',']),
                                       deterministic=True)
-            self.cursor.execute("""VACUUM;""")
             self.cursor.execute("""DROP TABLE IF EXISTS diary_temp;""")
             self.cursor.execute("""CREATE TABLE IF NOT EXISTS diary_temp(
                 create_order INTEGER NOT NULL,


### PR DESCRIPTION
When calling VACUUM at this point results in the sqlite3 error "cannot VACUUM from within a transaction". This prevents the app from properly initialising. Removing the command seems to allow it to start okay.

The issue only seems to happen on first run; on subsequent runs it doesn't cause problems.

Removing the command may not be the right way to fix it, but hopefully this PR will help identify the problem and point at the correct solution.